### PR TITLE
Handle Digitalocean spaces where region is part of the domain

### DIFF
--- a/models/AmazonS3.cfc
+++ b/models/AmazonS3.cfc
@@ -694,14 +694,14 @@ component accessors="true" singleton {
             if ( variables.awsDomain contains 'amazonaws.com' ) {
                 return "#HTTPPrefix##arguments.bucketName#.s3.amazonaws.com/#securedLink#";
             } else{
-                return "#HTTPPrefix##arguments.bucketName#.#variables.awsRegion#.#variables.awsDomain#/#securedLink#";
+                return "#HTTPPrefix##arguments.bucketName#." & ( len( variables.awsRegion ) ? '#variables.awsRegion#.' : '' ) & "#variables.awsDomain#/#securedLink#";
             }
 		}
 
         if ( variables.awsDomain contains 'amazonaws.com' ) {
             return "#HTTPPrefix#s3.amazonaws.com/#arguments.bucketName#/#securedLink#";
         } else{
-            return "#HTTPPrefix##variables.awsRegion#.#variables.awsDomain#/#arguments.bucketName#/#securedLink#";
+            return "#HTTPPrefix#" & ( len( variables.awsRegion ) ? "#variables.awsRegion#." : '' ) & "#variables.awsDomain#/#arguments.bucketName#/#securedLink#";
         }
     }
 


### PR DESCRIPTION
At least for our digitalocean spaces, in order for the regular logic behind **buildURLEndpoint()** to work, you have to specify what would be the "region" in the domain field, e.g. 

**awsDomain = 'nyc3.digitaloceanspaces.com**',
**awsRegion = ''**

Without putting DO-specific logic in the module, this small change will allow this configuration to work, since the only place it doesn't currently work is in `getAuthenticatedURL()` where it assumes region will have a value that needs to be included.