### PR TITLE
Rename encryption charset setting for consistency

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -24,7 +24,7 @@ component {
 			secretKey           : "",
 			awsDomain           : "amazonaws.com",
 			awsRegion           : "us-east-1",
-			encryption_charset  : "utf-8",
+			encryptionCharset  : "utf-8",
 			signatureType       : "V4",
 			ssl                 : true,
 			defaultTimeOut      : 300,
@@ -65,8 +65,8 @@ component {
 				value = variables.settings.awsregion
 			)
 			.initArg(
-				name  = "encryption_charset",
-				value = variables.settings.encryption_charset
+				name  = "encryptionCharset",
+				value = variables.settings.encryptionCharset
 			)
 			.initArg(
 				name  = "signatureType",

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -24,7 +24,7 @@ component {
 			secretKey           : "",
 			awsDomain           : "amazonaws.com",
 			awsRegion           : "us-east-1",
-			encryptionCharset  : "utf-8",
+			encryptionCharset   : "utf-8",
 			signatureType       : "V4",
 			ssl                 : true,
 			defaultTimeOut      : 300,

--- a/models/AmazonS3.cfc
+++ b/models/AmazonS3.cfc
@@ -96,7 +96,7 @@ component accessors="true" singleton {
 		required string secretKey,
 		string awsDomain           = "amazonaws.com",
 		string awsRegion           = "", // us-east-1 default for aws
-		string encryptionCharset  = "UTF-8",
+		string encryptionCharset   = "UTF-8",
 		string signatureType       = "V4",
 		boolean ssl                = true,
 		string defaultTimeOut      = 300,

--- a/models/AmazonS3.cfc
+++ b/models/AmazonS3.cfc
@@ -114,6 +114,13 @@ component accessors="true" singleton {
 		if ( arguments.awsDomain == "amazonaws.com" && arguments.awsRegion == "" ) {
 			arguments.awsRegion = "us-east-1";
 		}
+		/* 
+			Add backwards compatability for the previous key name
+			'encryption_charset'. Remove this from the next major release.
+		*/
+		if ( arguments.keyExists( "encryption_charset" ) ) {
+			arguments.encryptionCharset = arguments.encryption_charset;
+		}
 		variables.accessKey           = arguments.accessKey;
 		variables.secretKey           = arguments.secretKey;
 		variables.encryptionCharset   = arguments.encryptionCharset;

--- a/models/AmazonS3.cfc
+++ b/models/AmazonS3.cfc
@@ -114,7 +114,7 @@ component accessors="true" singleton {
 		if ( arguments.awsDomain == "amazonaws.com" && arguments.awsRegion == "" ) {
 			arguments.awsRegion = "us-east-1";
 		}
-		/* 
+		/*
 			Add backwards compatability for the previous key name
 			'encryption_charset'. Remove this from the next major release.
 		*/

--- a/models/AmazonS3.cfc
+++ b/models/AmazonS3.cfc
@@ -32,7 +32,7 @@ component accessors="true" singleton {
 	// Properties
 	property name="accessKey";
 	property name="secretKey";
-	property name="encryption_charset";
+	property name="encryptionCharset";
 	property name="ssl";
 	property name="URLEndpoint";
 	property name="awsRegion";
@@ -75,7 +75,7 @@ component accessors="true" singleton {
 	 * @secretKey The Amazon secret key.
 	 * @awsDomain The Domain used S3 Service (amazonws.com, digitalocean.com, storage.googleapis.com). Defaults to amazonws.com
 	 * @awsRegion The Amazon region. Defaults to us-east-1 for amazonaws.com
-	 * @encryption_charset The charset for the encryption. Defaults to UTF-8.
+	 * @encryptionCharset The charset for the encryption. Defaults to UTF-8.
 	 * @signature The signature version to calculate, "V2" is deprecated but more compatible with other endpoints. "V4" requires Sv4Util.cfc & ESAPI on Lucee. Defaults to V4
 	 * @ssl True if the request should use SSL. Defaults to true.
 	 * @defaultTimeOut Default HTTP timeout for all requests. Defaults to 300.
@@ -96,7 +96,7 @@ component accessors="true" singleton {
 		required string secretKey,
 		string awsDomain           = "amazonaws.com",
 		string awsRegion           = "", // us-east-1 default for aws
-		string encryption_charset  = "UTF-8",
+		string encryptionCharset  = "UTF-8",
 		string signatureType       = "V4",
 		boolean ssl                = true,
 		string defaultTimeOut      = 300,
@@ -116,7 +116,7 @@ component accessors="true" singleton {
 		}
 		variables.accessKey           = arguments.accessKey;
 		variables.secretKey           = arguments.secretKey;
-		variables.encryption_charset  = arguments.encryption_charset;
+		variables.encryptionCharset   = arguments.encryptionCharset;
 		variables.signatureType       = arguments.signatureType;
 		variables.awsDomain           = arguments.awsDomain;
 		variables.awsRegion           = arguments.awsRegion;
@@ -1279,8 +1279,8 @@ component accessors="true" singleton {
 		required string signKey,
 		required string signMessage
 	){
-		var jMsg = javacast( "string", arguments.signMessage ).getBytes( encryption_charset );
-		var jKey = javacast( "string", arguments.signKey ).getBytes( encryption_charset );
+		var jMsg = javacast( "string", arguments.signMessage ).getBytes( encryptionCharset );
+		var jKey = javacast( "string", arguments.signKey ).getBytes( encryptionCharset );
 		var key  = createObject(
 			"java",
 			"javax.crypto.spec.SecretKeySpec"

--- a/models/Sv2Util.cfc
+++ b/models/Sv2Util.cfc
@@ -90,8 +90,8 @@ component singleton {
 		required string signKey,
 		required string signMessage
 	){
-		var jMsg = javacast( "string", arguments.signMessage ).getBytes( encryption_charset );
-		var jKey = javacast( "string", arguments.signKey ).getBytes( encryption_charset );
+		var jMsg = javacast( "string", arguments.signMessage ).getBytes( encryptionCharset );
+		var jKey = javacast( "string", arguments.signKey ).getBytes( encryptionCharset );
 		var key  = createObject(
 			"java",
 			"javax.crypto.spec.SecretKeySpec"

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ This SDK will be installed into a directory called `s3sdk` and then the SDK can 
  * @secretKey The Amazon secret key.
  * @awsDomain The Domain used S3 Service (amazonws.com, digitalocean.com, storage.googleapis.com). Defaults to amazonws.com
  * @awsRegion The Amazon region. Defaults to us-east-1 for amazonaws.com
- * @encryption_charset The charset for the encryption. Defaults to UTF-8.
+ * @encryptionCharset The charset for the encryption. Defaults to UTF-8.
  * @signature The signature version to calculate, "V2" is deprecated but more compatible with other endpoints. "V4" requires Sv4Util.cfc & ESAPI on Lucee. Defaults to V4
  * @ssl True if the request should use SSL. Defaults to true.
  * @defaultTimeOut Default HTTP timeout for all requests. Defaults to 300.
@@ -59,7 +59,7 @@ public AmazonS3 function init(
 	required string secretKey,
 	string awsDomain = "amazonaws.com",
 	string awsRegion = "us-east-1",
-	string encryption_charset = "UTF-8",
+	string encryptionCharset = "UTF-8",
 	string signature = "V4",
 	boolean ssl = true,
 	string defaultTimeOut= 300,
@@ -86,7 +86,7 @@ moduleSettings = {
 		// Your amazon, digital ocean secret key
 		secretKey = "",
 		// The default encryption character set: defaults to utf-8
-		encryption_charset = "utf-8",
+		encryptionCharset = "utf-8",
 		// The signature version to calculate, "V2" is deprecated but more compatible with other endpoints. "V4" requires Sv4Util.cfc & ESAPI on Lucee. Defaults to V4
 		signature = "V4",
 		// SSL mode or not on cfhttp calls: Defaults to true

--- a/test-harness/.env.example
+++ b/test-harness/.env.example
@@ -2,6 +2,7 @@ AWS_ACCESS_KEY=
 AWS_ACCESS_SECRET=
 AWS_REGION=us-east-1
 AWS_DOMAIN=amazonaws.com
+AWS_DEFAULT_BUCKET_NAME=
 # This env var will be used in a bucket name for the test suite. It's not
 # required for local development. In CI, the ENGINE var will be defined by
 # the CI setup, so that we can test on several engines simultaneously without

--- a/test-harness/tests/index.cfm
+++ b/test-harness/tests/index.cfm
@@ -49,7 +49,7 @@
 	<meta charset="utf-8">
 	<meta name="generator" content="TestBox v#testbox.getVersion()#">
 	<title>TestBox Global Runner</title>
-	<script><cfinclude template="/testbox/system/reports/assets/js/jquery.js"></script>
+	<script><cfinclude template="/testbox/system/reports/assets/js/jquery-3.3.1.min.js"></script>
 	<script>
 	$(document).ready(function() {
 

--- a/test-harness/tests/specs/AmazonS3Spec.cfc
+++ b/test-harness/tests/specs/AmazonS3Spec.cfc
@@ -9,7 +9,8 @@ component extends="coldbox.system.testing.BaseTestCase" {
 			accessKey = getUtil().getSystemSetting( "AWS_ACCESS_KEY" ),
 			secretKey = getUtil().getSystemSetting( "AWS_ACCESS_SECRET" ),
 			awsRegion = getUtil().getSystemSetting( "AWS_REGION" ),
-			awsDomain = getUtil().getSystemSetting( "AWS_DOMAIN" )
+			awsDomain = getUtil().getSystemSetting( "AWS_DOMAIN" ),
+			defaultBucketName = getUtil().getSystemSetting( "AWS_DEFAULT_BUCKET_NAME", "" )
 		);
 		prepareMock( s3 );
 		s3.$property(

--- a/test-harness/tests/specs/AmazonS3Spec.cfc
+++ b/test-harness/tests/specs/AmazonS3Spec.cfc
@@ -6,10 +6,10 @@ component extends="coldbox.system.testing.BaseTestCase" {
 	function beforeAll(){
 		prepTmpFolder();
 		variables.s3 = new s3sdk.models.AmazonS3(
-			accessKey = getUtil().getSystemSetting( "AWS_ACCESS_KEY" ),
-			secretKey = getUtil().getSystemSetting( "AWS_ACCESS_SECRET" ),
-			awsRegion = getUtil().getSystemSetting( "AWS_REGION" ),
-			awsDomain = getUtil().getSystemSetting( "AWS_DOMAIN" ),
+			accessKey         = getUtil().getSystemSetting( "AWS_ACCESS_KEY" ),
+			secretKey         = getUtil().getSystemSetting( "AWS_ACCESS_SECRET" ),
+			awsRegion         = getUtil().getSystemSetting( "AWS_REGION" ),
+			awsDomain         = getUtil().getSystemSetting( "AWS_DOMAIN" ),
 			defaultBucketName = getUtil().getSystemSetting( "AWS_DEFAULT_BUCKET_NAME", "" )
 		);
 		prepareMock( s3 );

--- a/test-harness/tests/specs/AmazonS3Spec.cfc
+++ b/test-harness/tests/specs/AmazonS3Spec.cfc
@@ -9,8 +9,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 			accessKey = getUtil().getSystemSetting( "AWS_ACCESS_KEY" ),
 			secretKey = getUtil().getSystemSetting( "AWS_ACCESS_SECRET" ),
 			awsRegion = getUtil().getSystemSetting( "AWS_REGION" ),
-			awsDomain = getUtil().getSystemSetting( "AWS_DOMAIN" ),
-			defaultBucketName = getUtil().getSystemSetting( "AWS_DEFAULT_BUCKET_NAME", "" )
+			awsDomain = getUtil().getSystemSetting( "AWS_DOMAIN" )
 		);
 		prepareMock( s3 );
 		s3.$property(


### PR DESCRIPTION
This is a breaking change and would need to be on the next major release.

This PR renames the 'encryption_charset' setting to 'encryptionCharset' to be consistent with other settings.