### PR TITLE
Add missing warn() to MiniLogBox.cfc

### DIFF
--- a/models/MiniLogBox.cfc
+++ b/models/MiniLogBox.cfc
@@ -24,6 +24,13 @@ component {
 		}
 	}
 
+	function warn( required string msg, data ){
+		arrayAppend( variables.logs, "Warn: " & arguments.msg );
+		if ( structKeyExists( arguments, "data" ) ) {
+			arrayAppend( variables.logs, arguments.data );
+		}
+	}
+
 	array function getLogs(){
 		return variables.logs;
 	}


### PR DESCRIPTION
amazonS3.cfc calls log.warn() but minilogbox.cfc is missing this method.

This is needed for use outside of coldbox applications.