### PR TITLE
v5.8.1

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"Amazon S3 SDK",
-    "version":"5.8.0",
+    "version":"5.8.1",
     "slug":"s3sdk",
     "location":"https://downloads.ortussolutions.com/ortussolutions/coldbox-modules/s3sdk/@build.version@/s3sdk-@build.version@.zip",
     "author":"Ortus Solutions, Corp",

--- a/models/AmazonS3.cfc
+++ b/models/AmazonS3.cfc
@@ -430,7 +430,8 @@ component accessors="true" singleton {
 				"type"        : node.grantee.XMLAttributes[ "xsi:type" ],
 				"displayName" : "",
 				"permission"  : node.permission.XMLText,
-				"uri"         : node.grantee.XMLAttributes[ "xsi:type" ] == "Group" ? node.grantee.uri.xmlText : node.grantee.displayName.xmlText
+				// TODO:  
+				"uri"         : node.grantee.XMLAttributes[ "xsi:type" ] == "Group" ? node.grantee.uri.xmlText : ( node.grantee.displayName.xmlText ?:  node.grantee.ID.xmlText )
 			};
 		} );
 	}

--- a/models/AmazonS3.cfc
+++ b/models/AmazonS3.cfc
@@ -1776,7 +1776,7 @@ component accessors="true" singleton {
 			throw(
 				type    = "S3SDKError",
 				message = "Error making Amazon REST Call: #results.message#",
-				detail  = serializeJSON( results.response )
+				detail  = isXML( results.response ) ? toString( results.response ) : serializeJSON( results.response )
 			);
 		}
 


### PR DESCRIPTION
Patch to support AWS Deprecation of DisplayName in 2025:

> End of support notice: Beginning November 21, 2025, Amazon S3 will stop returning DisplayName. Update your applications to use canonical IDs (unique identifier for AWS accounts), AWS account ID (12 digit identifier) or IAM ARNs (full resource naming) as a direct replacement of DisplayName.
>
> Between July 15, 2025 and November 21, 2025, you will begin to see an increasing rate of missing DisplayName in the Owner object.
>
> This change affects the following AWS Regions: US East (N. Virginia) Region, US West (N. California) Region, US West (Oregon) Region, Asia Pacific (Singapore) Region, Asia Pacific (Sydney) Region, Asia Pacific (Tokyo) Region, Europe (Ireland) Region, and South America (São Paulo) Region.